### PR TITLE
extract gzip

### DIFF
--- a/ghettoVCB-restore.sh
+++ b/ghettoVCB-restore.sh
@@ -159,6 +159,15 @@ ghettoVCBrestore() {
         fi
 
         #supports DIR or .TGZ from ghettoVCB.sh ONLY!
+	if [ ${VM_TO_RESTORE##*.} == 'gz' ]; then
+            echo "GZ found, extracting ..."
+            if [ ! -f /bin/bash ]; then
+                busybox tar -xzf $VM_TO_RESTORE -C `dirname $VM_TO_RESTORE`
+            else
+                tar -xzf $VM_TO_RESTORE -C `dirname $VM_TO_RESTORE`
+            fi
+            VM_TO_RESTORE=${VM_TO_RESTORE%.*}
+        fi
         if [ -d "${VM_TO_RESTORE}" ]; then
             #figure out the contents of the directory (*.vmdk,*-flat.vmdk,*.vmx)
             VM_ORIG_VMX=$(ls "${VM_TO_RESTORE}" | grep ".vmx")

--- a/ghettoVCB-restore.sh
+++ b/ghettoVCB-restore.sh
@@ -159,13 +159,9 @@ ghettoVCBrestore() {
         fi
 
         #supports DIR or .TGZ from ghettoVCB.sh ONLY!
-	if [ ${VM_TO_RESTORE##*.} == 'gz' ]; then
-            echo "GZ found, extracting ..."
-            if [ ! -f /bin/bash ]; then
-                busybox tar -xzf $VM_TO_RESTORE -C `dirname $VM_TO_RESTORE`
-            else
-                tar -xzf $VM_TO_RESTORE -C `dirname $VM_TO_RESTORE`
-            fi
+        if [ ${VM_TO_RESTORE##*.} == 'gz' ]; then
+            logger "GZ found, extracting ..."
+            ${TAR} -xzf $VM_TO_RESTORE -C `dirname $VM_TO_RESTORE`
             VM_TO_RESTORE=${VM_TO_RESTORE%.*}
         fi
         if [ -d "${VM_TO_RESTORE}" ]; then


### PR DESCRIPTION
Backups can't be restored when they are gzipped. This fix implements a gunzip before extracting.