### PR TITLE
Fix auto-consolidate if/else logic

### DIFF
--- a/ghettoVCB.sh
+++ b/ghettoVCB.sh
@@ -888,14 +888,12 @@ ghettoVCB() {
             logger "dryrun" "###############################################\n"
 
         #checks to see if the VM has any snapshots to start with
-        elif ls "${VMX_DIR}" | grep -q "\-delta\.vmdk" > /dev/null 2>&1; then
-            if [ ${ALLOW_VMS_WITH_SNAPSHOTS_TO_BE_BACKEDUP} -eq 0 ]; then
-                logger "info" "Snapshot found for ${VM_NAME}, backup will not take place\n"
-                VM_FAILED=1
-            fi
         elif [[ -f "${VMX_PATH}" ]] && [[ ! -z "${VMX_PATH}" ]]; then
             if ls "${VMX_DIR}" | grep -q "\-delta\.vmdk" > /dev/null 2>&1; then
-                if [ ${ALLOW_VMS_WITH_SNAPSHOTS_TO_BE_BACKEDUP} -eq 1 ]; then
+                if [ ${ALLOW_VMS_WITH_SNAPSHOTS_TO_BE_BACKEDUP} -eq 0 ]; then
+                    logger "info" "Snapshot found for ${VM_NAME}, backup will not take place\n"
+                    VM_FAILED=1
+                else  
                     logger "info" "Snapshot found for ${VM_NAME}, consolidating ALL snapshots now (this can take awhile) ...\n"
                     $VMWARE_CMD vmsvc/snapshot.removeall ${VM_ID} > /dev/null 2>&1
                 fi


### PR DESCRIPTION
Dear lamw,

We are using ghettoVCB to backup our VMs. We really like the addition of the new "auto-consolidate snapshot" function, but found a glitch in its implementation.

Hopefully you agree, and merge this pull request to fix the issue.

The logic to auto-consolidate snapshots did not trigger consolidation - it merely logged that it should. This commit fixes the if/else logic around that decision.

Mark.
