### PR TITLE
Ignore vmdks from previous vm backups in the same backup run

### DIFF
--- a/ghettoVCB.sh
+++ b/ghettoVCB.sh
@@ -407,6 +407,9 @@ getVMDKs() {
     #get all VMDKs listed in .vmx file
     VMDKS_FOUND=$(grep -iE '(^scsi|^ide)' "${VMX_PATH}" | grep -i fileName | awk -F " " '{print $1}')
 
+    VMDKS=
+    INDEP_VMDKS=
+
     TMP_IFS=${IFS}
     IFS=${ORIG_IFS}
     #loop through each disk and verify that it's currently present and create array of valid VMDKS


### PR DESCRIPTION
Previously failed vm backups as part of the same backup run would spill
over their VMDKs to the next VM to be backed up. Seemed to happens when a vm shutdown timeout occured.