### PR TITLE
BUGFIX sendMail function fixes for errors during every run

### DIFF
--- a/ghettoVCB.sh
+++ b/ghettoVCB.sh
@@ -1322,8 +1322,9 @@ buildHeaders() {
 }
 
 sendMail() {
+    SMTP=0
     #close email message
-    if [[ "${EMAIL_LOG}" -eq 1 ]] || [[ "${EMAIL_ALERT}" -eq 1]] ; then
+    if [[ "${EMAIL_LOG}" -eq 1 ]] || [[ "${EMAIL_ALERT}" -eq 1 ]] ; then
         SMTP=1
         #validate firewall has email port open for ESXi 5
         if [[ "${VER}" == "5" ]] || [[ "${VER}" == "6" ]] ; then


### PR DESCRIPTION
Errors of
   ash: missing ]]
   ash: bad number
were displayed at the completion of each run of gettoVCB.sh. These were due to minor issues in the sendMail function
- Add a missing "space" to fix the second comparison expression in the first if of the function
- Set SMTP to zero at function entry, to handle the case where email is not being sent.
