### PR TITLE
Ensure period for SMTP is on a line of its own

### DIFF
--- a/ghettoVCB.sh
+++ b/ghettoVCB.sh
@@ -1314,7 +1314,7 @@ buildHeaders() {
     echo -ne "XMailer: ghettoVCB ${VERSION_STRING}\r\n" >> "${EMAIL_LOG_HEADER}"
     echo -en "\r\n" >> "${EMAIL_LOG_HEADER}"
 
-    echo -en ".\r\n" >> "${EMAIL_LOG_OUTPUT}"
+    echo -en "\r\n.\r\n" >> "${EMAIL_LOG_OUTPUT}"
     echo -en "QUIT\r\n" >> "${EMAIL_LOG_OUTPUT}"
 
     cat "${EMAIL_LOG_HEADER}" > "${EMAIL_LOG_CONTENT}"


### PR DESCRIPTION
This change obeys the SMTP RFC closer and will allow more SMTP servers to work correctly. Current code has the "ghettoVCB LOG END" ending with \n, then in buildheaders it puts the SMTP "." right after that, making it "\n.\r\n". Some servers don't see this as a new line. It should be "\r\n.\r\n" so it is for sure on a new line.