### PR TITLE
Included cleanup of partial failed backup

### DIFF
--- a/ghettoVCB.sh
+++ b/ghettoVCB.sh
@@ -1105,6 +1105,9 @@ ghettoVCB() {
 
                                     if [[ "${VMDK_EXIT_CODE}" != 0 ]] ; then
                                         logger "info" "ERROR: error in backing up of \"${SOURCE_VMDK}\" for ${VM_NAME}"
+					# clean up partial backup
+                                        logger "info" "Deleting partial backup: ${VM_BACKUP_DIR}/${DS_UUID}"
+                                        rm -rf "${VM_BACKUP_DIR}/${DS_UUID}"
                                         VM_VMDK_FAILED=1
                                     fi
                                 fi


### PR DESCRIPTION
If a backup fails, the rotation script will delete a previous good backup without a new good backup.

This cleans up the backup, though does not handle the creation of the STATUS.error file - shouldn't this be left to the logs? I don't know how else this can be handled.

The alternative would be to not rotate on error, but if you start with 2 good, 1 bad with rotate of 2. You now have 2 good 1 bad and then on the 4th backup which is good (2 good 1 bad 1 good) the rotation would cull 2 good leaving 1 bad 1 good which still isn't ideal.

#107 