### PR TITLE
Add NVME to list of storage options for ESXi 6.5

### DIFF
--- a/ghettoVCB.sh
+++ b/ghettoVCB.sh
@@ -413,7 +413,7 @@ findVMDK() {
 
 getVMDKs() {
     #get all VMDKs listed in .vmx file
-    VMDKS_FOUND=$(grep -iE '(^scsi|^ide|^sata)' "${VMX_PATH}" | grep -i fileName | awk -F " " '{print $1}')
+    VMDKS_FOUND=$(grep -iE '(^scsi|^ide|^sata|^nvme)' "${VMX_PATH}" | grep -i fileName | awk -F " " '{print $1}')
 
     VMDKS=
     INDEP_VMDKS=


### PR DESCRIPTION
Add NVME to list of storage options, for ESXi 6.5, to allow backups to complete successfully when configured with NVME controller and hard disks. I made the change, and it is working on my end.