### PR TITLE
Made addition to line 781

### DIFF
--- a/ghettoVCB.sh
+++ b/ghettoVCB.sh
@@ -778,7 +778,7 @@ ghettoVCB() {
             #1 = readonly
             #0 = readwrite
             logger "debug" "Mounting NFS: ${NFS_SERVER}:${NFS_MOUNT} to /vmfs/volume/${NFS_LOCAL_NAME}"
-	    if [[ ${ESX_RELEASE} == "5.5.0" ]] || [[ ${ESX_RELEASE} == "6.0.0" ]] ; then
+	    if [[ ${ESX_RELEASE} == "5.5.0" ]] || [[ ${ESX_RELEASE} == "6.0.0" ]] || [[ ${ESX_RELEASE} == "6.5.0" ]]; then
                 ${VMWARE_CMD} hostsvc/datastore/nas_create "${NFS_LOCAL_NAME}" "${NFS_VERSION}" "${NFS_MOUNT}" 0 "${NFS_SERVER}"
             else
                 ${VMWARE_CMD} hostsvc/datastore/nas_create "${NFS_LOCAL_NAME}" "${NFS_SERVER}" "${NFS_MOUNT}" 0


### PR DESCRIPTION
In your if statement on line 781, the ESX_RELEASE check is only for ESXi versions 5.5 and 6.0.  There is no check for 6.5.  When ran against a 6.5 host, it reverts to else statement concluding in the script being unable to run because it has the wrong command for mounting an NFS share.