### PR TITLE
Fix Insufficient arguments nas_create when using non persitent NFS

### DIFF
--- a/ghettoVCB.sh
+++ b/ghettoVCB.sh
@@ -778,7 +778,7 @@ ghettoVCB() {
             #1 = readonly
             #0 = readwrite
             logger "debug" "Mounting NFS: ${NFS_SERVER}:${NFS_MOUNT} to /vmfs/volume/${NFS_LOCAL_NAME}"
-	    if [[ ${ESX_RELEASE} == "5.5.0" ]] || [[ ${ESX_RELEASE} == "6.0.0" ]] ; then
+	    if [[ ${ESX_RELEASE} == "5.5.0" ]] || [[ "${VER}" == "6" ]] ; then
                 ${VMWARE_CMD} hostsvc/datastore/nas_create "${NFS_LOCAL_NAME}" "${NFS_VERSION}" "${NFS_MOUNT}" 0 "${NFS_SERVER}"
             else
                 ${VMWARE_CMD} hostsvc/datastore/nas_create "${NFS_LOCAL_NAME}" "${NFS_SERVER}" "${NFS_MOUNT}" 0


### PR DESCRIPTION
When non persistent NFS is used, the nas_create command used for ESX 6.5.0 is missing arguments.
The cause is that the check was done on ESX_VERSION 6.0.0 without taking into account ESX 6.5.0. Solved by relying on "${VER}" == "6" to cover all 6.x versions