### PR TITLE
fix missing whitespace in if statement for sanity check for VM_BACKUP…

### DIFF
--- a/ghettoVCB.sh
+++ b/ghettoVCB.sh
@@ -1522,7 +1522,7 @@ if [[ $# -lt 1 ]] || [[ $# -gt 12 ]]; then
 fi
 
 #Quick sanity check for the VM_BACKUP_ROTATION_COUNT configuration setting.
-if [[ "$VM_BACKUP_ROTATION_COUNT" -lt 1]]; then
+if [[ "$VM_BACKUP_ROTATION_COUNT" -lt 1 ]]; then
 	VM_BACKUP_ROTATION_COUNT=1
 fi
 


### PR DESCRIPTION
…_ROTATION_COUNT

single missing whitespace in the if statement for the sanity check for VM_BACKUP_ROTATION_COUNT, right before the closing ]].

The issue went away with the simple addition of this whitespace.  Only occurred when running backup from interactive shell, I only testet on one host, with one particular VM in a list, and using -d dryrun. 