### PR TITLE
Change shutdown snapshot backup logic

### DIFF
--- a/ghettoVCB.sh
+++ b/ghettoVCB.sh
@@ -189,6 +189,7 @@ printUsage() {
         echo
         echo "OPTIONS:"
         echo "   -a     Backup all VMs on host"
+        echo "   -e     Path to VM exclusion list"
         echo "   -f     List of VMs to backup"
         echo "   -m     Name of VM to backup (overrides -f)"
         echo "   -c     VM configuration directory for VM backups"
@@ -533,7 +534,7 @@ dumpVMConfigurations() {
     logger "info" "CONFIG - GHETTOVCB_PID = ${GHETTOVCB_PID}"
     logger "info" "CONFIG - VM_BACKUP_VOLUME = ${VM_BACKUP_VOLUME}"
     logger "info" "CONFIG - ENABLE_NON_PERSISTENT_NFS = ${ENABLE_NON_PERSISTENT_NFS}"
-	if [[ "${ENABLE_NON_PERSISTENT_NFS}" -eq 1 ]]; then
+    if [[ "${ENABLE_NON_PERSISTENT_NFS}" -eq 1 ]]; then
         logger "info" "CONFIG - UNMOUNT_NFS = ${UNMOUNT_NFS}"
         logger "info" "CONFIG - NFS_SERVER = ${NFS_SERVER}"
         logger "info" "CONFIG - NFS_VERSION = ${NFS_VERSION}"
@@ -567,18 +568,18 @@ dumpVMConfigurations() {
         logger "info" "CONFIG - EMAIL_TO = ${EMAIL_TO}"
         logger "info" "CONFIG - WORKDIR_DEBUG = ${WORKDIR_DEBUG}"
     fi
-	if [[ "${ENABLE_NFS_IO_HACK}" -eq 1 ]]; then
-		logger "info" "CONFIG - ENABLE NFS IO HACK = ${ENABLE_NFS_IO_HACK}"
-		logger "info" "CONFIG - NFS IO HACK LOOP MAX = ${NFS_IO_HACK_LOOP_MAX}"
-		logger "info" "CONFIG - NFS IO HACK SLEEP TIMER = ${NFS_IO_HACK_SLEEP_TIMER}"
-		logger "info" "CONFIG - NFS BACKUP DELAY = ${NFS_BACKUP_DELAY}\n"
-	else
-	    logger "info" "CONFIG - ENABLE NFS IO HACK = ${ENABLE_NFS_IO_HACK}\n"
-	fi
+    if [[ "${ENABLE_NFS_IO_HACK}" -eq 1 ]]; then
+		    logger "info" "CONFIG - ENABLE NFS IO HACK = ${ENABLE_NFS_IO_HACK}"
+        logger "info" "CONFIG - NFS IO HACK LOOP MAX = ${NFS_IO_HACK_LOOP_MAX}"
+        logger "info" "CONFIG - NFS IO HACK SLEEP TIMER = ${NFS_IO_HACK_SLEEP_TIMER}"
+        logger "info" "CONFIG - NFS BACKUP DELAY = ${NFS_BACKUP_DELAY}\n"
+    else
+        logger "info" "CONFIG - ENABLE NFS IO HACK = ${ENABLE_NFS_IO_HACK}\n"
+    fi
 }
 
 # Added the function below to allow reuse of the basics of the original hack in more places in the script.
-# Rewrote the code to reduce the calls to the NAS when it slows.  Why make a bad situation worse with extra calls? 
+# Rewrote the code to reduce the calls to the NAS when it slows.  Why make a bad situation worse with extra calls?
 NfsIoHack() {
     # NFS I/O error handling hack
     NFS_IO_HACK_COUNTER=0
@@ -715,7 +716,7 @@ checkVMBackupRotation() {
 			# Added the NFS_IO_HACK check and function call here.  Also set the script to function the same, if the new feature is turned off.
             # Added variables to the code to control the timers and loops.
             # This code could be optimized based on the work in the NFS_IO_HACK function or that code could be used all the time with a few minor changes.
-            if [[ $? -ne 0 ]] && [[ "${ENABLE_NFS_IO_HACK}" -eq 1 ]]; then 
+            if [[ $? -ne 0 ]] && [[ "${ENABLE_NFS_IO_HACK}" -eq 1 ]]; then
                 NfsIoHack
             else
 				#NFS I/O error handling hack
@@ -893,12 +894,12 @@ ghettoVCB() {
             #1 = readonly
             #0 = readwrite
             logger "debug" "Mounting NFS: ${NFS_SERVER}:${NFS_MOUNT} to /vmfs/volume/${NFS_LOCAL_NAME}"
-	    if [[ ${ESX_RELEASE} == "5.5.0" ]] || [[ ${ESX_RELEASE} == "6.0.0" || ${ESX_RELEASE} == "6.5.0" || ${ESX_RELEASE} == "6.7.0" ]] ; then
+            if [[ ${ESX_RELEASE} == "5.5.0" ]] || [[ ${ESX_RELEASE} == "6.0.0" || ${ESX_RELEASE} == "6.5.0" || ${ESX_RELEASE} == "6.7.0" ]] ; then
                 ${VMWARE_CMD} hostsvc/datastore/nas_create "${NFS_LOCAL_NAME}" "${NFS_VERSION}" "${NFS_MOUNT}" 0 "${NFS_SERVER}"
             else
                 ${VMWARE_CMD} hostsvc/datastore/nas_create "${NFS_LOCAL_NAME}" "${NFS_SERVER}" "${NFS_MOUNT}" 0
             fi
-	fi
+        fi
     fi
 
     captureDefaultConfigurations
@@ -1053,7 +1054,7 @@ ghettoVCB() {
                     $VMWARE_CMD vmsvc/snapshot.removeall ${VM_ID} > /dev/null 2>&1
                 fi
             fi
-    	    #nfs case and backup to root path of your NFS mount
+            #nfs case and backup to root path of your NFS mount
             if [[ ${ENABLE_NON_PERSISTENT_NFS} -eq 1 ]] ; then
                 BACKUP_DIR="/vmfs/volumes/${NFS_LOCAL_NAME}/${NFS_VM_BACKUP_DIR}/${VM_NAME}"
                 if [[ -z ${VM_NAME} ]] || [[ -z ${NFS_LOCAL_NAME} ]] || [[ -z ${NFS_VM_BACKUP_DIR} ]]; then
@@ -1061,7 +1062,7 @@ ghettoVCB() {
                     exit 1
                 fi
 
-                #non-nfs (SAN,LOCAL)
+            #non-nfs (SAN,LOCAL)
             else
                 BACKUP_DIR="${VM_BACKUP_VOLUME}/${VM_NAME}"
                 if [[ -z ${VM_BACKUP_VOLUME} ]]; then
@@ -1351,8 +1352,8 @@ ghettoVCB() {
 		# Added the Brute-force delay in case it is needed.
 		if [[ "${ENABLE_NFS_IO_HACK}" -eq 1 ]]; then
 			NfsIoHack
-			sleep "${NFS_BACKUP_DELAY}" 
-		fi 
+			sleep "${NFS_BACKUP_DELAY}"
+		fi
     done
     # UNTESTED CODE
     # Why is this outside of the main loop & it looks like checkVMBackupRotation() could be called twice?

--- a/ghettoVCB.sh
+++ b/ghettoVCB.sh
@@ -8,7 +8,7 @@
 #                   User Definable Parameters
 ##################################################################
 
-LAST_MODIFIED_DATE=2019_02_05
+LAST_MODIFIED_DATE=2019_02_07
 VERSION=1
 
 # directory that all VM backups should go (e.g. /vmfs/volumes/SAN_LUN1/mybackupdir)
@@ -1127,7 +1127,7 @@ ghettoVCB() {
                 VM_VMDK_FAILED=0
 
                 #powered on VMs only
-                if [[ ! ${POWER_VM_DOWN_BEFORE_BACKUP} -eq 1 ]] && [[ "${ORGINAL_VM_POWER_STATE}" != "Powered off" ]]; then
+                if [[ "${ORGINAL_VM_POWER_STATE}" != "Powered off" ]]; then
                     SNAPSHOT_NAME="ghettoVCB-snapshot-$(date +%F)"
                     logger "info" "Creating Snapshot \"${SNAPSHOT_NAME}\" for ${VM_NAME}"
                     ${VMWARE_CMD} vmsvc/snapshot.create ${VM_ID} "${SNAPSHOT_NAME}" "${SNAPSHOT_NAME}" "${VM_SNAPSHOT_MEMORY}" "${VM_SNAPSHOT_QUIESCE}" > /dev/null 2>&1
@@ -1243,7 +1243,7 @@ ghettoVCB() {
                 fi
 
                 #powered on VMs only w/snapshots
-                if [[ ${SNAP_SUCCESS} -eq 1 ]] && [[ ! ${POWER_VM_DOWN_BEFORE_BACKUP} -eq 1 ]] && [[ "${ORGINAL_VM_POWER_STATE}" == "Powered on" ]] || [[ "${ORGINAL_VM_POWER_STATE}" == "Suspended" ]]; then
+                if [[ ${SNAP_SUCCESS} -eq 1 ]] && [[ "${ORGINAL_VM_POWER_STATE}" == "Powered on" ]] || [[ "${ORGINAL_VM_POWER_STATE}" == "Suspended" ]]; then
                     if [[ "${NEW_VIMCMD_SNAPSHOT}" == "yes" ]] ; then
                         SNAPSHOT_ID=$(${VMWARE_CMD} vmsvc/snapshot.get ${VM_ID} | grep -E '(Snapshot Name|Snapshot Id)' | grep -A1 ${SNAPSHOT_NAME} | grep "Snapshot Id" | awk -F ":" '{print $2}' | sed -e 's/^[[:blank:]]*//;s/[[:blank:]]*$//')
                         ${VMWARE_CMD} vmsvc/snapshot.remove ${VM_ID} ${SNAPSHOT_ID} > /dev/null 2>&1

--- a/rc.local
+++ b/rc.local
@@ -1,0 +1,37 @@
+
+####################### start ghettoVCB #######################
+# add this to /etc/rc.local.d/local.sh BEFORE the 'exit 0'!
+
+# create firewall config for ghettoVCB mail
+VCBDIR="/vmfs/volumes/<DATASTORE>/scripts/ghettoVCB"
+HOST=$(hostname -s)
+if [ -d ${VCBDIR} ]; then
+   if [ -f ${VCBDIR}/vcb-smtp.xml -a ! -f /etc/vmware/firewall/vcb-smtp.xml ] ; then
+      cp -p ${VCBDIR}/vcb-smtp.xml /etc/vmware/firewall/
+      localcli network firewall refresh
+   fi
+fi
+
+# create crontab entries for ghettoVCB script
+/bin/kill $(cat /var/run/crond.pid)
+CRONTAB="/var/spool/cron/crontabs/root"
+
+# cleanup current crontab
+grep -v "ghettoVCB" ${CRONTAB} >/tmp/crontab-root.tmp
+chmod 0444 /tmp/crontab-root.tmp
+chmod -t ${CRONTAB}
+mv /tmp/crontab-root.tmp ${CRONTAB}
+chmod +t ${CRONTAB}
+
+# ATTENTION: start time is in UTC, not local time!
+# to start at 19:33 local time
+# CET:  33 18 <--
+# CEST: 33 17
+echo "33   18   *   *   *   ${VCBDIR}/ghettoVCB-wrapper.sh >${VCBDIR}/${HOST}-wrapper.log 2>&1"  >> ${CRONTAB}
+/bin/crond
+
+# load multiextent module for 2gbsparse - needed with 5.0u3/5.1u1 and newer,
+# doesn't hurt on other systems
+localcli system module load -m multiextent
+
+######################## end ghettoVCB ########################

--- a/vcb-smtp.xml
+++ b/vcb-smtp.xml
@@ -1,0 +1,14 @@
+<!-- Firewall configuration information for vcb-smtp -->
+<ConfigRoot>
+  <service>
+    <id>vcb-smtp</id>
+    <rule id='0000'>
+      <direction>outbound</direction>
+      <protocol>tcp</protocol>
+      <porttype>dst</porttype>
+      <port>25</port>
+    </rule>
+    <enabled>true</enabled>
+    <required>false</required>
+  </service>
+</ConfigRoot>


### PR DESCRIPTION
I moved the block powering back on a VM with POWER_VM_DOWN_BEFORE_BACKUP=1 right above the actual backup takes place to shorten the downtime. Also made sure that such VMs are snapshotted too (otherwise it wouldn't work).

While i was here i documented the -e parameter and corrected some indentation (most of it was auto-corrected by Atom editor).

I ran a few tests and they worked for me so far. I will use this version on an internal production server starting 2/12/2019 and report back after the first backup runs were made.

My intention to make this change are database servers and Windows domain controllers to ensure a clean ("cold") backup in a guaranteed clean state while keeping downtimes still short.