### PR TITLE
Allow SMTP firewall ruleset id to contain 1-space separator

### DIFF
--- a/ghettoVCB.sh
+++ b/ghettoVCB.sh
@@ -1467,7 +1467,7 @@ sendMail() {
         SMTP=1
         #validate firewall has email port open for ESXi 5
         if [[ "${VER}" == "5" ]] || [[ "${VER}" == "6" ]] || [[ "${VER}" == "7" ]]; then
-            /sbin/esxcli network firewall ruleset rule list | awk '{print $5}' | grep "^${EMAIL_SERVER_PORT}$" > /dev/null 2>&1
+            /sbin/esxcli network firewall ruleset rule list | awk -F'[ ]{2,}' '{print $5}' | grep "^${EMAIL_SERVER_PORT}$" > /dev/null 2>&1
             if [[ $? -eq 1 ]] ; then
                 logger "info" "ERROR: Please enable firewall rule for email traffic on port ${EMAIL_SERVER_PORT}\n"
                 logger "info" "Please refer to ghettoVCB documentation for ESXi 5 firewall configuration\n"


### PR DESCRIPTION
Someone uses the ruleset id as the ruleset name i.e. she/he uses
single space separator sentences e.g. "SMTP out".
This way of doing breaks the 5-th column value extraction done via awk.

Whilst using space separator could be wrong, this commit enhance column
value extraction by imposing the proper separator according to the CLI
output.

Tested on VMware ESXi 6.7.0 build-15820472.

# Test environment
Ruleset to allow outbound SMTP traffic:
``` bash
[root@host:~] cat /etc/vmware/firewall/smtp-out.xml
<ConfigRoot>
  <service>
    <id>SMTP out</id>
    <rule id="0000">
      <direction>outbound</direction>
      <protocol>tcp</protocol>
      <porttype>dst</porttype>
      <port>25</port>
    </rule>
    <enabled>true</enabled>
    <required>false</required>
  </service>
</ConfigRoot>
```
Current set of rules:
``` bash
[root@host:~] /sbin/esxcli network firewall ruleset rule list
Ruleset                 Direction  Protocol  Port Type  Port Begin  Port End
----------------------  ---------  --------  ---------  ----------  --------
sshServer               Inbound    TCP       Dst                22        22
sshClient               Outbound   TCP       Dst                22        22
nfsClient               Outbound   TCP       Dst                 0     65535
nfs41Client             Outbound   TCP       Dst                 0     65535
[...]
vic-engine              Outbound   TCP       Dst              2377      2377
vsanhealth-unicasttest  Outbound   UDP       Dst              5201      5201
vsanhealth-unicasttest  Inbound    UDP       Dst              5201      5201
vsanhealth-unicasttest  Outbound   TCP       Dst              5201      5201
vsanhealth-unicasttest  Inbound    TCP       Dst              5201      5201
SMTP out                Outbound   TCP       Dst                25        25
```
Current `awk` extraction which **breaks** on `SMTP out`:
``` bash
[root@esxi01:~] /sbin/esxcli network firewall ruleset rule list | awk '{print $5}'
Type
----------
22
22
0
0
[...]
2377
5201
5201
5201
5201
Dst
```
Imposing the proper separator will help the 5-th column extraction, see `Port begin` too:
``` bash
[root@host:~] /sbin/esxcli network firewall ruleset rule list | awk -F'[ ]{2,}' '{print $5}'
Port Begin
----------
22
22
0
0
[...]
2377
5201
5201
5201
5201
25
```