### PR TITLE
Handle --adaptertype deprecated for vmdkfstool

### DIFF
--- a/ghettoVCB.sh
+++ b/ghettoVCB.sh
@@ -1209,7 +1209,7 @@ ghettoVCB() {
                                     [[ -n "${ADAPTER_FORMAT}" ]] && ADAPTER_FORMAT="-a ${ADAPTER_FORMAT}"
 
                                     logger "debug" "${VMKFSTOOLS_CMD} -i \"${SOURCE_VMDK}\" ${ADAPTER_FORMAT} ${FORMAT_OPTION} \"${DESTINATION_VMDK}\""
-                                    eval ${VMKFSTOOLS_CMD} -i "${SOURCE_VMDK}" ${ADAPTER_FORMAT} ${FORMAT_OPTION} "${DESTINATION_VMDK}" > "${VMDK_OUTPUT}" 2>&1
+                                    eval ${VMKFSTOOLS_CMD} -i '"${SOURCE_VMDK}"' ${ADAPTER_FORMAT} ${FORMAT_OPTION} '"${DESTINATION_VMDK}"' > '"${VMDK_OUTPUT}"' 2>&1
 
                                     VMDK_EXIT_CODE=$?
                                     kill "${TAIL_PID}"

--- a/ghettoVCB.sh
+++ b/ghettoVCB.sh
@@ -295,7 +295,7 @@ sanityCheck() {
         echo "ERROR: Unable to locate *vimsh*! You're not running ESX(i) 3.5+, 4.x+, 5.x+ or 6.x!"
         exit 1
     fi
-    if ${VMKFSTOOLS_CMD} 2>&1 -h | grep -F -e '--adaptertype' | grep -qF 'deprecated'; then
+    if ${VMKFSTOOLS_CMD} 2>&1 -h | grep -F -e '--adaptertype' | grep -qF 'deprecated' || ! ${VMKFSTOOLS_CMD} 2>&1 -h | grep -F -e '--adaptertype'; then
         ADAPTERTYPE_DEPRECATED=1
     fi
 

--- a/ghettoVCB.sh
+++ b/ghettoVCB.sh
@@ -1186,12 +1186,12 @@ ghettoVCB() {
                                         FORMAT_OPTION=""
                                     fi
                                 elif [[ "${DISK_BACKUP_FORMAT}" == "2gbsparse" ]] ; then
-                                    FORMAT_OPTION="2gbsparse"
+                                    FORMAT_OPTION="-d 2gbsparse"
                                 elif [[ "${DISK_BACKUP_FORMAT}" == "thin" ]] ; then
-                                    FORMAT_OPTION="thin"
+                                    FORMAT_OPTION="-d thin"
                                 elif [[ "${DISK_BACKUP_FORMAT}" == "eagerzeroedthick" ]] ; then
                                     if [[ "${VER}" == "4" ]] || [[ "${VER}" == "5" ]] || [[ "${VER}" == "6" ]] || [[ "${VER}" == "7" ]]; then
-                                        FORMAT_OPTION="eagerzeroedthick"
+                                        FORMAT_OPTION="-d eagerzeroedthick"
                                     else
                                         FORMAT_OPTION=""
                                     fi

--- a/ghettoVCB.sh
+++ b/ghettoVCB.sh
@@ -295,7 +295,7 @@ sanityCheck() {
         echo "ERROR: Unable to locate *vimsh*! You're not running ESX(i) 3.5+, 4.x+, 5.x+ or 6.x!"
         exit 1
     fi
-    if vmkfstools 2>&1 -h | grep -F -e '--adaptertype' | grep -qF 'deprecated'; then
+    if ${VMKFSTOOLS_CMD} 2>&1 -h | grep -F -e '--adaptertype' | grep -qF 'deprecated'; then
         ADAPTERTYPE_DEPRECATED=1
     fi
 


### PR DESCRIPTION
ADAPTERTYPE_DEPRECATED:
vmdkfstool --adaptertype option is deprecated now (from ESXi 6.5?)
In this patch, we ask vmdkfstool about it.

FORMAT_OPTION:
All format option is a word without spaces(2gbsparse, thin, etc), so we can handle it without if; then; else; fi

ADAPTER_FORMAT:
All adapter format is a word without spaces or deprecated (buslogic, lsilogic, ide, lsisas, pvscsi), so we can handle it without if; then; else; fi

And now we can use one "eval" line to call "vmkfstool"/