### PR TITLE
ghettoVCB VIB/Offline Bundle build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,16 @@
 # ghettoVCB
 
-### Description
+## Description
 
-The ghettoVCB script performs backups of virtual machines residing on ESX(i) 3.x, 4.x, 5.x & 6.x servers using methodology similar to VMware's VCB tool. The script takes snapshots of live running virtual machines, backs up the  master VMDK(s) and then upon completion, deletes the snapshot until the next backup. The only caveat is that it utilizes resources available to the ESXi Shell running the backups as opposed to following the traditional method of offloading virtual machine backups through a VCB proxy.
+The ghettoVCB script performs backups of virtual machines residing on ESX(i) 3.x, 4.x, 5.x, 6.x & 7.x servers using methodology similar to VMware's VCB tool. The script takes snapshots of live running virtual machines, backs up the  master VMDK(s) and then upon completion, deletes the snapshot until the next backup. The only caveat is that it utilizes resources available to the ESXi Shell running the backups as opposed to following the traditional method of offloading virtual machine backups through a VCB proxy.
 
-### How to install
+## Download
 
-You can quickly install/update ghettoVCB by downloading and install either the VIB or offline bundle using the following commands. If you wish to update to latest ghettoVCB release and are using the ghettovcb.conf file and wish to have the setting persist, make sure to use the *update* command instead of *install*
+Latest ghettoVCB VIB and Offline Bundle can be downloaded from [here](https://github.com/lamw/ghettoVCB/releases)
+
+## Install
+
+You can quickly install/update ghettoVCB by downloading and installing either the [VIB or offline bundle](https://github.com/lamw/ghettoVCB/releases) using the following commands. If you wish to update to latest ghettoVCB release and are using the ghettovcb.conf file and wish to have the setting persist, make sure to use the *update* command instead of *install*
 
 More details on using the ghettoVCB VIB/Offline Bundle can be found in this blog post [here](https://www.virtuallyghetto.com/2015/05/ghettovcb-vib-offline-bundle-for-esxi.html)
 
@@ -30,16 +34,20 @@ Update offline bundle
 esxcli software vib update -d /vghetto-ghettoVCB-offline-bundle.zip -f
 ```
 
-### Additional Documentation & Resources
+## Build VIB/Offline Bundle
+
+See the build documentation [here](build/README.md)
+
+## Additional Documentation & Resources
 - [ghettoVCB Documentation](http://communities.vmware.com/docs/DOC-8760)
 - [ghettoVCB VMTN Group](http://communities.vmware.com/groups/ghettovcb)
 - [ghettoVCB Restore Documentation](http://communities.vmware.com/docs/DOC-10595)
 
-### Licensing
+## Licensing
 
 The MIT License (MIT)
 
-Copyright (c) 2015 www.virtuallyghetto.com!
+Copyright (c) 2021 www.virtuallyghetto.com!
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,0 +1,15 @@
+FROM lamw/vibauthor
+
+# Due to https://stackoverflow.com/a/49026601
+RUN rpm --rebuilddb
+RUN yum clean all
+RUN yum update -y nss curl libcurl;yum clean all
+
+# Copy ghettoVCB VIB build script
+COPY create_ghettoVCB_vib.sh create_ghettoVCB_vib.sh
+RUN chmod +x create_ghettoVCB_vib.sh
+
+# Run ghettoVCB VIB build script
+RUN /root/create_ghettoVCB_vib.sh
+
+CMD ["/bin/bash"]

--- a/build/README.md
+++ b/build/README.md
@@ -1,0 +1,58 @@
+# Build ghettoVCB VIB/Offline Bundle
+
+The `build.sh` shell script is used to create both the ghettoVCB VIB and Offline Bundle which is available for download in the [ghettoVCB Releases page](https://github.com/lamw/ghettoVCB/releases). For those interested, you can also use this script to generate your own VIB/Offline Bundled which automatically pulls from the latest ghettoVCB source code.
+
+The build script requires `docker` to be installed and uses the [vibauthor docker](https://hub.docker.com/repository/docker/lamw/vibauthor) container to generate the VIB/Offline Bundle.
+
+Here is an example of running the script:
+
+```code
+❯ ./build.sh
+
+Untagged: ghettovcb:latest
+Deleted: sha256:af50b3cc12eec9277e04921e556fe6a62c64d9e503d850d7de59a9cf47b401bb
+Deleted: sha256:bbf8b88d685825840508451014e38f84e459ffb75e7b2a4e185e7f5c47c7b618
+Deleted: sha256:a72afa7385618d5865b88300b1889385b9e6204547bd88c6f719fb15a81217e3
+Deleted: sha256:d221fb0ba5af54c0de4d15e2eec3fdafcee97fd895aab6c359372fd76f84b339
+Sending build context to Docker daemon  6.656kB
+Step 1/8 : FROM lamw/vibauthor
+ ---> a673ffe4ba43
+Step 2/8 : RUN rpm --rebuilddb
+ ---> Using cache
+ ---> 753af48ef9af
+Step 3/8 : RUN yum clean all
+ ---> Using cache
+ ---> 689b05a480e2
+Step 4/8 : RUN yum update -y nss curl libcurl;yum clean all
+ ---> Using cache
+ ---> c51671aed6fa
+Step 5/8 : COPY create_ghettoVCB_vib.sh create_ghettoVCB_vib.sh
+ ---> 7d2e7dffd928
+Step 6/8 : RUN chmod +x create_ghettoVCB_vib.sh
+ ---> Running in feaffc690f72
+Removing intermediate container feaffc690f72
+ ---> 25dbc3dee22a
+Step 7/8 : RUN /root/create_ghettoVCB_vib.sh
+ ---> Running in 9eae129c4da1
+Initialized empty Git repository in /root/ghettoVCB/.git/
+Successfully created vghetto-ghettoVCB.vib.
+Successfully created vghetto-ghettoVCB-offline-bundle.zip.
+Removing intermediate container 9eae129c4da1
+ ---> ddb549b11636
+Step 8/8 : CMD ["/bin/bash"]
+ ---> Running in dda3680d7a69
+Removing intermediate container dda3680d7a69
+ ---> 616ef9508225
+Successfully built 616ef9508225
+Successfully tagged ghettovcb:latest
+```
+
+Upon success, you should have a new directory called `artifacts` which contains both the VIB and Offline Bundle
+
+```code
+❯ tree artifacts
+
+artifacts
+├── vghetto-ghettoVCB-offline-bundle.zip
+└── vghetto-ghettoVCB.vib
+```

--- a/build/build.sh
+++ b/build/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+docker rmi -f ghettovcb
+rm -rf artifacts
+docker build -t ghettovcb .
+docker run -i -v ${PWD}/artifacts:/artifacts ghettovcb sh << COMMANDS
+cp vghetto-ghettoVCB* /artifacts
+COMMANDS

--- a/build/create_ghettoVCB_vib.sh
+++ b/build/create_ghettoVCB_vib.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+# William Lam
+# www.virtuallyghetto.com
+# Script to build ghettoVCB VIB using VIB Author (can use with lamw/vibauthor Docker Container)
+
+GVCB_REPO=https://github.com/lamw/ghettoVCB.git
+GVCB_REPO_DIR=ghettoVCB
+GVCB_TEMP_DIR=/tmp/ghettoVCB-$$
+
+# Ensure git is installed
+git version > /dev/null 2>&1
+if [ $? -eq 1 ]; then
+	echo "Git not installed, exiting ..."
+	exit 1
+fi
+
+# Ensure vibauthor is installed
+vibauthor --version > /dev/null 2>&1
+if [ $? -eq 1 ]; then
+	echo "vibauthor not installed, exiting ..."
+	exit 1
+fi
+
+# Ensure no existing ghettoVCB repo exists
+if [ -e ${GVCB_REPO_DIR} ]; then
+	rm -rf ${GVCB_REPO_DIR}
+fi
+
+# Clone ghettoVCB repo
+git clone ${GVCB_REPO}
+cd ${GVCB_REPO_DIR}
+GVCB_DATE=$(date --date="$(git log -n1 --format="%cd" --date="iso")" '+%Y-%m-%dT%H:%I:%S')
+GVCB_COMMIT_HASH=$(git log -n1 --format="%H")
+cd /root
+
+# Setting up VIB spec confs
+VIB_DESC_FILE=${GVCB_TEMP_DIR}/descriptor.xml
+VIB_PAYLOAD_DIR=${GVCB_TEMP_DIR}/payloads/payload1
+
+# Create ghettoVCB temp dir
+mkdir -p ${GVCB_TEMP_DIR}
+# Create VIB spec payload directory
+mkdir -p ${VIB_PAYLOAD_DIR}
+
+# Create ghettoVCB VIB descriptor.xml
+cat > ${VIB_DESC_FILE} << __GHETTOVCB__
+<vib version="5.0">
+  <type>bootbank</type>
+  <name>ghettoVCB</name>
+  <version>1.0.0-0.0.0</version>
+  <vendor>virtuallyGhetto</vendor>
+  <summary>ghettoVCB VM backup and restore script</summary>
+  <description>${GVCB_COMMIT_HASH}</description>
+  <release-date>${GVCB_DATE}</release-date>
+  <urls>
+    <url key="ghettoVCB">https://github.com/lamw/ghettoVCB</url>
+  </urls>
+  <relationships>
+    <depends>
+    </depends>
+    <conflicts/>
+    <replaces/>
+    <provides/>
+    <compatibleWith/>
+  </relationships>
+  <software-tags>
+  </software-tags>
+  <system-requires>
+    <maintenance-mode>false</maintenance-mode>
+  </system-requires>
+  <file-list>
+  </file-list>
+  <acceptance-level>community</acceptance-level>
+  <live-install-allowed>true</live-install-allowed>
+  <live-remove-allowed>true</live-remove-allowed>
+  <cimom-restart>false</cimom-restart>
+  <stateless-ready>true</stateless-ready>
+  <overlay>false</overlay>
+  <payloads>
+    <payload name="payload1" type="vgz"></payload>
+  </payloads>
+</vib>
+__GHETTOVCB__
+
+# Create ghettoVCB bin/conf directories
+GVCB_BIN_DIR=${VIB_PAYLOAD_DIR}/opt/ghettovcb/bin
+GVCB_CONF_DIR=${VIB_PAYLOAD_DIR}/opt/ghettovcb
+mkdir -p ${GVCB_BIN_DIR}
+mkdir -p ${GVCB_CONF_DIR}
+
+# Copy ghettoVCB files to bin/conf directories
+cp ${GVCB_REPO_DIR}/*.sh ${GVCB_BIN_DIR}
+cp ${GVCB_REPO_DIR}/*.conf ${GVCB_CONF_DIR}
+cp ${GVCB_REPO_DIR}/*_template ${GVCB_CONF_DIR}
+
+# Ensure config files are writable
+chmod -R +tw ${GVCB_CONF_DIR}
+
+# Create ghettoVCB VIB + offline bundle
+vibauthor -C -t ${GVCB_TEMP_DIR} -v vghetto-ghettoVCB.vib -O vghetto-ghettoVCB-offline-bundle.zip -f
+
+# Remove ghettoVCB temp dir
+rm -rf ${GVCB_TEMP_DIR}


### PR DESCRIPTION
Added `build` directory which contains all the necessary scripts to create ghettoVCB VIB/Offline Bundle from the latest ghettoVCB source code. These scripts are also used to generate the official ghettoVCB releases and can be used to create VIB/Offline Bundle from the latest code changes. 

While incorporating the build scripts, I have also modified the default path of the ghettoVCB configuration files to be placed in `/opt/ghettovcb` versus `/etc/ghettovcb` so that ESXi upgrades can be performed _while_ ghettoVCB is installed. Previously, this would require uninstalling and re-installing ghettoVCB which is not a great experience.

This PR resolves:
Closes #158 
Closes #63 