### PR TITLE
Fix version detection for ESXi 7.0.x

### DIFF
--- a/ghettoVCB-restore.sh
+++ b/ghettoVCB-restore.sh
@@ -93,7 +93,7 @@ sanityCheck() {
     ESX_VERSION=$(vmware -v | awk '{print $3}')
 
     case "${ESX_VERSION}" in
-        7.0.0|7.0.1|7.0.2)    VER=7; break;;
+        7.0.*)                VER=7; break;;
         6.0.0|6.5.0|6.7.0)    VER=6; break;;
         5.0.0|5.1.0|5.5.0)    VER=5; break;;
         4.0.0|4.1.0)          VER=4; break;;

--- a/ghettoVCB.sh
+++ b/ghettoVCB.sh
@@ -308,7 +308,7 @@ sanityCheck() {
     ESX_RELEASE=$(uname -r)
 
     case "${ESX_VERSION}" in
-	    7.0.0|7.0.1|7.0.2)    VER=7; break;;
+        7.0.*)                VER=7; break;;
         6.0.0|6.5.0|6.7.0)    VER=6; break;;
         5.0.0|5.1.0|5.5.0)    VER=5; break;;
         4.0.0|4.1.0)          VER=4; break;;


### PR DESCRIPTION
Hi William,

version detection broke again with the latest update to 7.0.3. I suggest using a wildcard match for 7.0.x as present in this pull request.

Kind regards,
Patrick