### PR TITLE
mail send fails on long username/password

### DIFF
--- a/ghettoVCB.sh
+++ b/ghettoVCB.sh
@@ -1486,8 +1486,8 @@ buildHeaders() {
     if [[ ! -z "${EMAIL_USER_NAME}" ]]; then
         echo -ne "EHLO $(hostname -s)\r\n" >> "${EMAIL_LOG_HEADER}"
         echo -ne "AUTH LOGIN\r\n" >> "${EMAIL_LOG_HEADER}"
-        echo -ne "$(echo -n "${EMAIL_USER_NAME}" |openssl base64 2>&1 |tail -1)\r\n" >> "${EMAIL_LOG_HEADER}"
-        echo -ne "$(echo -n "${EMAIL_USER_PASSWORD}" |openssl base64 2>&1 |tail -1)\r\n" >> "${EMAIL_LOG_HEADER}"
+        echo -ne "$(echo -n "${EMAIL_USER_NAME}" |openssl enc -A -base64 2>&1 |tail -1)\r\n" >> "${EMAIL_LOG_HEADER}"
+        echo -ne "$(echo -n "${EMAIL_USER_PASSWORD}" |openssl enc -A -base64 2>&1 |tail -1)\r\n" >> "${EMAIL_LOG_HEADER}"
     fi
     echo -ne "MAIL FROM: <${EMAIL_FROM}>\r\n" >> "${EMAIL_LOG_HEADER}"
     echo -ne "RCPT TO: <${EMAIL_ADDRESS}>\r\n" >> "${EMAIL_LOG_HEADER}"


### PR DESCRIPTION
if the username/password are too long - the current bas64 does return the result including a newline which makes the authentication to the SMTP server fail - the proposed change makes sure that the base64 is returned in a single line.

Tested with SendGrid SMPT and apikey - the suggested change fixes the described issue.