### PR TITLE
Refactor ESXi version check for NFS mount command

### DIFF
--- a/ghettoVCB.sh
+++ b/ghettoVCB.sh
@@ -905,7 +905,7 @@ ghettoVCB() {
             #1 = readonly
             #0 = readwrite
             logger "debug" "Mounting NFS: ${NFS_SERVER}:${NFS_MOUNT} to /vmfs/volume/${NFS_LOCAL_NAME}"
-	    if [[ ${ESX_RELEASE} == "5.5.0" ]] || [[ ${ESX_RELEASE} == "6.0.0" || ${ESX_RELEASE} == "6.5.0" || ${ESX_RELEASE} == "6.7.0" || ${ESX_RELEASE} == "7.0.0" || ${ESX_RELEASE} == "7.0.1" || ${ESX_RELEASE} == "7.0.2" || ${ESX_RELEASE} == "7.0.3" ]] ; then
+        if [[ ${ESX_RELEASE} != "3i" ]] || [[ ${ESX_RELEASE} != "3.5.0" || ${ESX_RELEASE} != "4.0.0" || ${ESX_RELEASE} != "4.1.0" || ${ESX_RELEASE} != "5.0.0" || ${ESX_RELEASE} != "5.1.0" ]] ; then
                 ${VMWARE_CMD} hostsvc/datastore/nas_create "${NFS_LOCAL_NAME}" "${NFS_VERSION}" "${NFS_MOUNT}" 0 "${NFS_SERVER}"
             else
                 ${VMWARE_CMD} hostsvc/datastore/nas_create "${NFS_LOCAL_NAME}" "${NFS_SERVER}" "${NFS_MOUNT}" 0


### PR DESCRIPTION
Closes #273 

This change refactors the ESXi version check and rather than keep appending news versions that already support the updated vim-cmd NFS mount command, I'm now only checking for the versions that do not support and hence keeping the code easier to manage