### PR TITLE
ghettoVCB.sh: pigz compression instead of gzip

### DIFF
--- a/ghettoVCB.sh
+++ b/ghettoVCB.sh
@@ -1313,9 +1313,12 @@ ghettoVCB() {
                 if [[ ${ENABLE_COMPRESSION} -eq 1 ]] ; then
                     COMPRESSED_ARCHIVE_FILE="${BACKUP_DIR}/${VM_NAME}-${VM_BACKUP_DIR_NAMING_CONVENTION}.gz"
 
-                    logger "info" "Compressing VM backup \"${COMPRESSED_ARCHIVE_FILE}\"..."
-                    ${TAR} -cz -C "${BACKUP_DIR}" "${VM_NAME}-${VM_BACKUP_DIR_NAMING_CONVENTION}" -f "${COMPRESSED_ARCHIVE_FILE}"
-
+                    logger "info" "Compressing VM backup \"${COMPRESSED_ARCHIVE_FILE}\"..."                    
+		    # original compression using single-threaded gzip only
+		    # ${TAR} -cz -C "${BACKUP_DIR}" "${VM_NAME}-${VM_BACKUP_DIR_NAMING_CONVENTION}" -f "${COMPRESSED_ARCHIVE_FILE}"
+      		    # new compression with pigz utilizing more CPU cores resulting in drastically faster compression (here: 24 cores, "-p 24")
+	            ${TAR} cf -C "${BACKUP_DIR}" "${VM_NAME}-${VM_BACKUP_DIR_NAMING_CONVENTION}" | pigz -p 24 > "${COMPRESSED_ARCHIVE_FILE}"
+			
                     # verify compression
                     if [[ $? -eq 0 ]] && [[ -f "${COMPRESSED_ARCHIVE_FILE}" ]]; then
                         logger "info" "Successfully compressed backup for ${VM_NAME}!\n"


### PR DESCRIPTION
Compression now utlilizes 24 CPU cores with pigz instead of single-threaded gzip, resulting in drastically faster compression.

Example: 180GB thin-provisioned disk with ~22GB used, compressed to ~19 GB
- gzip compression: ~144 minutes
- pigz compression with 24 cores: ~11 minutes

Successfully tested on ESXi-version 6.5.0, including successful restore.

To utilize a different number of cores (in this commit: 24 cores) change "-p 24" on line 1320 of ghettoVCB.sh.

Todo: make the # of cores configurable via configfile