### PR TITLE
Use -d flag for zeroedthick in ESXi 7

### DIFF
--- a/ghettoVCB.sh
+++ b/ghettoVCB.sh
@@ -1235,7 +1235,7 @@ ghettoVCB() {
                                 FORMAT_OPTION="UNKNOWN"
                                 if [[ "${DISK_BACKUP_FORMAT}" == "zeroedthick" ]] ; then
                                     if [[ "${VER}" == "4" ]] || [[ "${VER}" == "5" ]] || [[ "${VER}" == "6" ]] || [[ "${VER}" == "7" ]] ; then
-                                        FORMAT_OPTION="zeroedthick"
+                                        FORMAT_OPTION="-d zeroedthick"
                                     else
                                         FORMAT_OPTION=""
                                     fi


### PR DESCRIPTION
In order to backup a VM with zeroedthick provisioning on ESXi 7.0.3, I had to use the -d flag on vmkfstools, just like the other provisioning methods.